### PR TITLE
Added: printError function utils.h for streamlined error output

### DIFF
--- a/src/ChocAnSystem.cpp
+++ b/src/ChocAnSystem.cpp
@@ -6,13 +6,13 @@
 #include <sstream>
 #include <fstream>
 #include "ChocAnSystem.h"
+#include "Utils.h"
 
 using namespace std;
 
 const string MEMBER_REPORT_FOLDER = "src/reports/members/";
 const string PROVIDER_REPORT_FOLDER = "src/reports/providers/";
 const string SUMMARY_REPORT_FOLDER = "src/reports/summaries/";
-
 const string PROVIDDER_DIRECTORY_PATH = "src/reports/Provider_Directory.txt";
 
 ChocAnSystem::ChocAnSystem()
@@ -86,7 +86,7 @@ void ChocAnSystem::getProviderDirectory()
     if (writeProviderDirectoryToFile(providerDirectory, PROVIDDER_DIRECTORY_PATH)) {
         cout << "\n>> Provider Directory saved, file path: " << PROVIDDER_DIRECTORY_PATH << endl;
     } else {
-        cerr << "Failed to saved Provider Directory." << endl;
+        printError("Failed to save provider directory.");
     }
 }
 
@@ -105,7 +105,7 @@ void ChocAnSystem::generateMemberReport(const std::string &memberID)
     const string format = "%Y-%m-%d";   // Date format for fileName
 
     if (member.isEmpty()) {
-        cout << "\nMember does not exist" << endl;
+        printError("Member not found.");
         return;
     }
 
@@ -170,9 +170,11 @@ void ChocAnSystem::generateMemberReport(const std::string &memberID)
 void ChocAnSystem::printReport(const std::string &filePath)
 {
     ifstream file(filePath);
+    string chocan_errmsg{};
 
     if (!file.is_open()) {
-        cerr << "\nFailed to open file " << filePath << endl;
+        chocan_errmsg = "Failed to open file: " + filePath + " due to missing permissions or incorrect path.";
+        printError(chocan_errmsg);
         return;
     }
     
@@ -198,7 +200,7 @@ void ChocAnSystem::generateProviderReport(const std::string &providerID)
     const string format = "%Y-%m-%d";
 
     if (provider.isEmpty()) {
-        cout << "\nProvider does not exist" << endl;
+        printError("Provider not found.");
         return;
     }
 
@@ -433,9 +435,11 @@ void ChocAnSystem::displayProviderDirectory(std::vector<Service> &providerDirect
 bool ChocAnSystem::writeProviderDirectoryToFile(vector<Service> &services, const string & filePath)
 {
     ofstream writeToFile(filePath);
+    string chocan_errmsg{};
 
     if (!writeToFile.is_open()) {
-        cerr << "Error: Could Open file " << filePath << endl;
+        chocan_errmsg = "Failed to open file " + filePath + " due to missing permissions or incorrect path.";
+        printError(chocan_errmsg);
         return false;
     }
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <string>
 #include <limits>
 
 inline void clearScreen() {
@@ -23,4 +24,8 @@ inline void pressEnterToContinue(const std::string& text) {
     std::cout << text;
     std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
     clearScreen();
+}
+
+inline void printError(const std::string & message) {
+    std::cerr << "[ERROR] " << message << std::endl;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,7 +98,7 @@ main() {
                 session = make_unique<OperatorTerminal>();
                 // check for session == nullptr;
                 if (session == nullptr) {
-                    cerr << "Error: cannot start Operator Terminal!" << endl;
+                    printError("Cannot start Operator Terminal!");
                     return EXIT_FAILURE;
                 }
                 break;
@@ -107,7 +107,7 @@ main() {
                 session = make_unique<ManagerTerminal>();
                 // check for session == nullptr;
                 if (session == nullptr) {
-                    cerr << "Error: cannot start Manager Terminal!" << endl;
+                    printError("Cannot start Manager Terminal!");
                     return EXIT_FAILURE;
                 }
                 break;
@@ -116,18 +116,18 @@ main() {
                 session = make_unique<ProviderTerminal>();
                 // check for session == nullptr;
                 if (session == nullptr) {
-                    cerr << "Error: cannot start Manager Terminal!" << endl;
+                    printError("Cannot start Manager Terminal!");
                     return EXIT_FAILURE;
                 }
 
                 break;
 
             case (-1):
-                cout << "Invalid UserID, no assigned terminal for this role!" << endl;
+                printError("Invalid UserID, no assigned terminal for this role!");
                 break;
 
             default: // other case
-                cerr << "Error: undefined userID cases. End Terminal!" << endl;
+                printError("Undefined userID cases. End Terminal!");
                 exit(EXIT_FAILURE);
             }
                
@@ -141,7 +141,7 @@ main() {
             pressEnterToContinue();
         }
         else
-            cerr << "Error: invalid userID!" <<endl;
+            printError("Invalid user ID.");
     } while (1);
 
     return EXIT_SUCCESS;
@@ -174,7 +174,7 @@ void getInput(T &input, const string &prompt)
     while (!(cin >>input)) {
         cin.clear();
         cin.ignore(1024, '\n');
-
+        
         cout << "Invalid input format. please try again.\n > ";
     }
 }

--- a/src/terminals/ManagerTerminal.cpp
+++ b/src/terminals/ManagerTerminal.cpp
@@ -2,6 +2,7 @@
 #include <cassert>
 #include "ManagerTerminal.h"
 #include "../ChocAnSystem.h"
+#include "../Utils.h"
 
 using namespace std;
 
@@ -63,7 +64,7 @@ void ManagerTerminal::printMemberReport()
         getInput(memberID, "Enter member ID:\n > ");
 
         if (!(isValidateID = validateIDFormat(memberID))) {
-            cout << "Invalid Member ID format (9-digit), please try again.";
+            cout << "Invalid Member ID format (9-digit), please try again." << endl;
         }
     } while (!isValidateID);
 
@@ -80,7 +81,7 @@ void ManagerTerminal::printProviderReport()
         getInput(providerID, "Enter Provider ID:\n > ");
 
         if (!(isValidateID = validateIDFormat(providerID))) {
-            cout << "Invalid Provider ID format (9-digit), please try again.";
+            cout << "Invalid Provider ID format (9-digit), please try again." << endl;
         }
     } while (!isValidateID);
 

--- a/src/terminals/OperatorTerminal.cpp
+++ b/src/terminals/OperatorTerminal.cpp
@@ -134,7 +134,7 @@ void OperatorTerminal::addMember()
         cout << "\nMember added successfully." << endl;
     }
     else {
-        cout << "\nFailed to add new Member." << endl;
+        printError("\nFailed to add new Member.");
     }
     return;
 }
@@ -145,6 +145,7 @@ void OperatorTerminal::updateMember()
     bool confirm{ false };
     string memberID{};
     string new_address{}, new_city{}, new_state{}, new_zip{};
+    string chocan_errmsg{};
     bool isValidID{ false };
 
     cout << "[Update Member]" << endl;
@@ -159,7 +160,8 @@ void OperatorTerminal::updateMember()
 
     // check if member exist
     if (!(ChocAnSystem::getInstance().searchMember(memberID))) {
-        cerr << "No Member with memberID " << memberID << " exist." << endl;
+        chocan_errmsg = "Member with ID " + memberID + " not found.";
+        printError(chocan_errmsg);
         return;
     }
 
@@ -190,13 +192,15 @@ void OperatorTerminal::updateMember()
         cout << "\nMember with MemberID " << memberID << " Updated successfully." << endl;
     }
     else {
-        cout << "\nFailed to Update Member " << memberID << endl;
+        chocan_errmsg = "Update failed for member " + memberID; 
+        printError(chocan_errmsg);
     }
 }
 
 void OperatorTerminal::deleteMember()
 {
     string memberID{};
+    string chocan_errmsg{};
     bool isValidMemberID{ false };
 
     cout << "[Delete Member]" << endl;
@@ -209,14 +213,16 @@ void OperatorTerminal::deleteMember()
 
     // Check if memberID is in database
     if (!(ChocAnSystem::getInstance().searchMember(memberID))) {
-        cout << "\nCannot delete member: No such member exist" << endl;
+        chocan_errmsg = "Deletion failed: Member not found.";
+        printError(chocan_errmsg);
     }
     else {
         if ((ChocAnSystem::getInstance().deleteMember(memberID))) {
             cout << "\nMember is deleted successfully" << endl;
         }
         else {
-            cout << "\nCannot deleted Member with MemberID: " << memberID << endl;
+            chocan_errmsg = "Deletion failed: database error. Cannot delete member with Member ID " + memberID; 
+            printError(chocan_errmsg);
         }
     }
 }
@@ -278,7 +284,7 @@ void OperatorTerminal::addProvider()
         cout << "\nProvider added successfully." << endl;
     }
     else {
-        cout << "\nFailed to add new Provider." << endl;
+        printError("Failed to add new provider.");
     }
 }
 
@@ -288,6 +294,7 @@ void OperatorTerminal::updateProvider()
     bool confirm{ false };
     string providerID{};
     string new_address{}, new_city{}, new_state{}, new_zip{};
+    string chocan_errmsg{};
     bool isValidID{ false };
 
     cout << "[Update Provider]" << endl;
@@ -301,7 +308,8 @@ void OperatorTerminal::updateProvider()
 
     // check if provider exist
     if (!(ChocAnSystem::getInstance().searchProvider(providerID))) {
-        cerr << "No Provider with providerID " << providerID << " exist." << endl;
+        chocan_errmsg = "Provider with ID " + providerID + " not found."; 
+        printError(chocan_errmsg);
         return;
     }
 
@@ -332,13 +340,15 @@ void OperatorTerminal::updateProvider()
         cout << "\nProvider with ID " << providerID << " updated successfully." << endl;
     }
     else {
-        cout << "\nFailed to update provider with ID " << providerID << endl;
+        chocan_errmsg = "Failed to update provider with ID " + providerID;
+        printError(chocan_errmsg);
     }
 }
 
 void OperatorTerminal::deleteProvider()
 {
     string providerID{};
+    string Chocan_errmsg{};
     bool isValidProviderID{ false };
 
     cout << "[Delete Provider]" << endl;
@@ -351,14 +361,16 @@ void OperatorTerminal::deleteProvider()
 
     // Check if providerID is in database
     if (!(ChocAnSystem::getInstance().searchProvider(providerID))) {
-        cout << "\nCannot delete provider: No such provider exists" << endl;
+        Chocan_errmsg = "Deletion failed: Provider not found.";
+        printError(Chocan_errmsg);
     }
     else {
         if ((ChocAnSystem::getInstance().deleteProvider(providerID))) {
             cout << "\nProvider is deleted successfully" << endl;
         }
         else {
-            cout << "\nCannot delete Provider with ProviderID: " << providerID << endl;
+            Chocan_errmsg = "\nFailed to delete provider with ProviderID: " + providerID + " due to database error.";
+            printError(Chocan_errmsg);
         }
     }
 }

--- a/src/terminals/ProviderTerminal.cpp
+++ b/src/terminals/ProviderTerminal.cpp
@@ -245,7 +245,7 @@ float ProviderTerminal::billService()
         cout << "\nService Logged Successfully" << endl;
     } else {
         // If false: output "Error: Failed to Log current service!"
-        cerr << "\nFailed to log current service" << endl;
+        printError("\nFailed to log current service");
         exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
Added a function call printError: it will format the error output to std::cerr with the format cerr << "[ERROR] " << errmsg << endl;
